### PR TITLE
Firefox session cookie

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -291,7 +291,7 @@ class Firefox(BrowserCookieLoader):
 
                 if 'json_data' in locals():
                     expires = str(int(time.time()) + 3600 * 24 * 7)
-                    for window in json_data.get('windows', []):
+                    for window in json_data.get('windows', []) + [json_data]:
                         for cookie in window.get('cookies', []):
                             yield create_cookie(cookie.get('host', ''), cookie.get('path', ''), False, expires, cookie.get('name', ''), cookie.get('value', ''))
                 else:


### PR DESCRIPTION
Mozilla/5.0 (Windows NT 6.3; Win64; x64; rv:93.0) Gecko/20100101 Firefox/93.0
cookie is at top level, not under windows.
json_data.keys()
[u'windows', u'browserToolbox', u'session', u'selectedWindow', u'cookies', u'version', u'_closedWindows', u'lastSessionState', u'global', u'browserConsole']