### PR TITLE
Google Chrome Cookie positions

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -111,6 +111,7 @@ class Chrome(BrowserCookieLoader):
             os.path.expanduser('~/.config/vivaldi/Default/Cookies'),
             os.path.expanduser('~/.config/vivaldi/Profile */Cookies'),
             os.path.join(os.getenv('APPDATA', ''), r'..\Local\Google\Chrome\User Data\Default\Cookies'),
+            os.path.join(os.getenv('APPDATA', ''), r'..\Local\Google\Chrome\User Data\Default\Network\Cookies'),
             os.path.join(os.getenv('APPDATA', ''), r'..\Local\Google\Chrome\User Data\Profile *\Cookies'),
             os.path.join(os.getenv('APPDATA', ''), r'..\Local\Vivaldi\User Data\Default\Cookies'),
             os.path.join(os.getenv('APPDATA', ''), r'..\Local\Vivaldi\User Data\Profile *\Cookies'),


### PR DESCRIPTION
Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.99 Safari/537.36
find $LOCALAPPDATA -name Cookies
AppData\Local/Google/Chrome/User Data/Default/Network/Cookies