### PR TITLE
fix: win10 chrome cookie path add new

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -113,6 +113,7 @@ class Chrome(BrowserCookieLoader):
             os.path.join(os.getenv('APPDATA', ''), r'..\Local\Google\Chrome\User Data\Default\Cookies'),
             os.path.join(os.getenv('APPDATA', ''), r'..\Local\Google\Chrome\User Data\Default\Network\Cookies'),
             os.path.join(os.getenv('APPDATA', ''), r'..\Local\Google\Chrome\User Data\Profile *\Cookies'),
+            os.path.join(os.getenv('APPDATA', ''), r'..\Local\Google\Chrome\User Data\Profile *\Network\Cookies'),
             os.path.join(os.getenv('APPDATA', ''), r'..\Local\Vivaldi\User Data\Default\Cookies'),
             os.path.join(os.getenv('APPDATA', ''), r'..\Local\Vivaldi\User Data\Profile *\Cookies'),
         ]:


### PR DESCRIPTION
add new cookie path for Chrome in Win10
```
C:\Users\<username>\AppData\Local\Google\Chrome\User Data\<profile>\Network\Cookies
```