### PR TITLE
Handle Firefox installed using Snap

### DIFF
--- a/browsercookie/__init__.py
+++ b/browsercookie/__init__.py
@@ -342,7 +342,9 @@ class Firefox(BrowserCookieLoader):
         if sys.platform == 'darwin':
             return glob.glob(os.path.expanduser('~/Library/Application Support/Firefox/profiles.ini'))
         elif sys.platform.startswith('linux'):
-            return glob.glob(os.path.expanduser('~/.mozilla/firefox/profiles.ini'))
+            trad_filename = glob.glob(os.path.expanduser('~/.mozilla/firefox/profiles.ini'))
+            snap_filename = glob.glob(os.path.expanduser('~/snap/firefox/common/.mozilla/firefox/profiles.ini'))
+            return trad_filename + snap_filename
         elif sys.platform == 'win32':
             return glob.glob(os.path.join(os.getenv('APPDATA', ''), 'Mozilla/Firefox/profiles.ini'))
         else:


### PR DESCRIPTION
**Context**

On Linux, [Snap](https://snapcraft.io/) is a common method to install Firefox. On the Ubuntu distribution (one of the most used), Snap is the default method to install Firefox since Ubuntu 21.10. The traditional method (using packages) had been removed in Ubuntu 22.04.

**Issue**

For now, browsercookie only handles the traditional Firefox method installation, that stores the `profiles.ini` file in `~/.mozilla/firefox/profiles.ini`. So, using browsercookie on Ubuntu >= 21.10 (here, Ubuntu 23.10) leads to a "Could not find default Firefox profile" error.

With browsercookie 0.7.8:

```
$ python3
Python 3.11.6 (main, Oct  8 2023, 05:06:43) [GCC 13.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import browsercookie
>>> a = browsercookie.firefox()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/plops/Documents/pythonProject/.venv/lib/python3.11/site-packages/browsercookie/__init__.py", line 570, in firefox
    return Firefox(cookie_files).load()
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/plops/Documents/pythonProject/.venv/lib/python3.11/site-packages/browsercookie/__init__.py", line 86, in __init__
    self.cookie_files = list(cookie_files)
                        ^^^^^^^^^^^^^^^^^^
  File "/home/plops/Documents/pythonProject/.venv/lib/python3.11/site-packages/browsercookie/__init__.py", line 354, in find_cookie_files
    raise BrowserCookieError('Could not find default Firefox profile')
browsercookie.BrowserCookieError: Could not find default Firefox profile
```

**Solution**

Add `~/snap/firefox/common/.mozilla/firefox/profiles.ini` to the list of files paths.

As the "traditional" method is still used, the current code must be kept.

To avoid regression on systems using both methods, the snap path must be set after the traditional one. In that (uncommon) case, only the first one will be kept a few lines after (`path = self.parse_profile(profile[0])`).

With this patch:

```
$ python3
Python 3.11.6 (main, Oct  8 2023, 05:06:43) [GCC 13.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import browsercookie
>>> a = browsercookie.firefox()
>>> len(a)
2864
```