### PR TITLE
ChromeBased: Fix various exceptions, move to Cryptography

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.egg-info/

--- a/browsercookie/__init__.py
+++ b/browsercookie/__init__.py
@@ -109,18 +109,16 @@ class ChromeBased(BrowserCookieLoader):
             passwords = [my_pass]
 
         elif sys.platform.startswith('linux'):
+            import secretstorage
+
             # running Chrome on Linux
             passwords = [b'peanuts']  # v10 key
-            try:
-                import secretstorage
 
-                bus = secretstorage.dbus_init()
+            with contextlib.closing(secretstorage.dbus_init()) as bus:
                 collection = secretstorage.get_default_collection(bus)
-                for item in collection.get_all_items():
-                    if item.get_label() in ['Chromium Safe Storage', 'Chrome Safe Storage']:
-                        passwords.append(item.get_secret())
-            except Exception as e:
-                print(e)
+                schema = "chrome_libsecret_os_crypt_password_v2"
+                for item in collection.search_items({"xdg:schema": schema}):
+                    passwords.append(item.get_secret())
 
             iterations = 1
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     long_description=read('README.md'),
     long_description_content_type='text/markdown',
     url='https://github.com/richardpenman/browsercookie',
-    install_requires=['pycryptodome', 'keyring', 'lz4',
+    install_requires=['cryptography', 'keyring', 'lz4',
                       'pywin32; sys_platform == "win32"'],
     license='lgpl'
 )


### PR DESCRIPTION
Hi everyone,

this updates `ChromeBased` to
1. Use Cryptography instead of Cryptodome: Cryptography already gets installed by keyring->secretstorage and has a clean and stable API.
2. Fix an exception in SQLite `cur.fetchall()` by setting text_factory to bytes and converting to UTF-8 manually where needed.
3. Remove the newly (>= v24) introduced sha256 hash at the beginning of decrypted cookies to get valid values again.
4. Get all compatible passwords from SecretStorage by using the schema name instead of Browser names.

This was tested on Linux only. In case this PR gets merged, I'd like to propose doing a new release soon afterwards, because in its current state cookies from Chrome-based browsers can't be extracted.