### PR TITLE
Make Firefox cookie expiration in seconds rather than ms

### DIFF
--- a/browsercookie/__init__.py
+++ b/browsercookie/__init__.py
@@ -418,6 +418,9 @@ class Firefox(BrowserCookieLoader):
                         cur.execute('select host, path, isSecure, expiry, name, value from moz_cookies')
 
                         for item in cur.fetchall():
+                            # Firefox expiry time is in ms rather than s. Python expects s
+                            # Convert expiry (4th field) to seconds by dividing by 1000
+                            item = (v if i != 3 else v/1000 for i, v in enumerate(item))
                             yield create_cookie(*item)
                 else:
                     json_data = None


### PR DESCRIPTION
I found that I had an expired in cookie from Firefox that was taking precedence over a cookie from Chrome that had not expired when I used `browsercookie.load()`. This was because cookies from Firefox were being added as having an expiration in ms rather than s.

The code to add them to the cookie jar sorts by expiration but the value for cookies from Firefox were far higher than on cookies from Chrome.

Additionally, Python expects expiration in seconds, therefore checks like `cookie.is_expired()` were returning `False` on cookies from Firefox even though they were expired.

This fix converts Firefox's expiration values from ms to s by dividing by 1000.

I should mention that this has only been tested on macOS